### PR TITLE
Add --no-trunc option to volume list

### DIFF
--- a/commands/app.go
+++ b/commands/app.go
@@ -17,7 +17,7 @@ var (
 
 	boolYAML, boolJSON, boolVerbose, boolDebug bool
 
-	boolAll, boolQuiet, boolNoHeader bool
+	boolAll, boolQuiet, boolNoHeader, boolNoTrunc bool
 )
 
 var app = &cobra.Command{


### PR DESCRIPTION
Regarding #9, more scriptable with `volume list`

```
$ talk2docker vol list --no-trunc --no-header
  1aaa1127a69d | build2_with_compose:/tmp/test:ro   | 2015-02-22 22:03:22 | /mnt/sda1/var/lib/docker/vfs/dir/1aaa1127a69ded46bcf363dbaf039274fab124a2d6cbaaecca8eead5b4a0cf25
  1aaa1127a69d | hello_world:/tmp/test              | 2015-02-22 22:03:22 | /mnt/sda1/var/lib/docker/vfs/dir/1aaa1127a69ded46bcf363dbaf039274fab124a2d6cbaaecca8eead5b4a0cf25
  0e02aeb4db1f | build2_with_compose:/tmp/docker:ro | 2015-02-22 00:46:14 | /home/docker
  0e02aeb4db1f | hello_world:/tmp/docker:ro         | 2015-02-22 00:46:14 | /home/docker
```
